### PR TITLE
Fix deadlock in "Subscribe to channel `foo` at a high rate/ publish u…

### DIFF
--- a/test/tests.go
+++ b/test/tests.go
@@ -3,6 +3,7 @@ package test
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pusher/pubsub-code-challenge/client"
@@ -239,9 +240,13 @@ var Tests = map[string]func(cli client.Client) error{
 		subErrChan := make(chan error, 1)
 		pubErrChan := make(chan error, 1)
 
+		wg := sync.WaitGroup{}
+		wg.Add(numSubscriptions)
+
 		for i := 0; i < numSubscriptions; i++ {
 			go func(idx int) {
 				sub, err := cli.Subscribe("chan" + fmt.Sprint(idx))
+				wg.Done()
 				if err != nil {
 					subErrChan <- err
 					return
@@ -258,7 +263,7 @@ var Tests = map[string]func(cli client.Client) error{
 			}(i)
 		}
 
-		time.Sleep(500 * time.Millisecond)
+		wg.Wait()
 
 		for i := 0; i < numSubscriptions; i++ {
 			go func(idx int) {


### PR DESCRIPTION
…niquely to each"

If subscribing to the requested channels takes longer than the sleep, the test deadlocks. This PR uses a wait group instead. If we want to test timings we should have an explicit test for it rather than a buggy one!